### PR TITLE
Specify default value for selectors

### DIFF
--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -278,6 +278,7 @@ class Menu(object):
 
         :param title: Title of the selector
         :param values: Values of the selector [('Item1', var1..), ('Item2'...)]
+        :param default: Index of default value to display
         :param onchange: Function when changing the selector
         :param onreturn: Function when pressing return button
         :param kwargs: Aditional parameters
@@ -285,6 +286,7 @@ class Menu(object):
         :type values: list
         :type onchange: function, NoneType
         :type onreturn: function, NoneType
+        :type default: int
         :return: Selector ID
         :rtype: int
         """

--- a/pygameMenu/selector.py
+++ b/pygameMenu/selector.py
@@ -21,11 +21,12 @@ class Selector(object):
     Selector object
     """
 
-    def __init__(self, title, elements, onchange=None, onreturn=None, **kwargs):
+    def __init__(self, title, elements, onchange=None, onreturn=None, default=0, **kwargs):
         """
         Constructor.
 
         :param elements: Elements of the selector
+        :param default: Index of default element to display
         :param kwargs: Optional arguments
         :param onchange: Event when changing the selector
         :param onreturn: Event when pressing return button
@@ -33,6 +34,7 @@ class Selector(object):
         :type elements: list
         :type onchange: function, NoneType
         :type onreturn: function, NoneType
+        :type default: int
         :type title: str
         """
         self._elements = elements
@@ -42,6 +44,9 @@ class Selector(object):
         self._on_return = onreturn
         self._title = title
         self._total_elements = len(elements)
+        
+        for k in range(0,default):
+            self.right()
 
     def update_elements(self, elements):
         """


### PR DESCRIPTION
Added option to selector objects to provide a default value to display instead of the first in the list. 

Recommended fix to Issue #10 

WARNING: This code is not backwards compatible with code that specifies kwargs for add_selector