### PR TITLE
Add mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Obviously you need <a href="http://www.pygame.org/download.shtml">Pygame</a> to 
     | font_size_title | Font size of the title | int | MENU_FONT_SIZE_TITLE |
     | font_title | Alternative font of the title (fil direction) | str | None |
     | joystick_enabled | Enable joystick support | bool | True |
+    | mouse_enabled | Enable mouse support | bool | True |
     | menu_alpha | Alpha of background (0=tansparent, 100=opaque) | int | MENU_ALPHA |
     | menu_centered | Text centered menu | bool | MENU_CENTERED_TEXT |
     | menu_color | Menu color | tuple | MENU_BGCOLOR |

--- a/example.py
+++ b/example.py
@@ -123,7 +123,8 @@ timer_menu = pygameMenu.Menu(surface,
                              title='Timer Menu',
                              title_offsety=5,  # Adds 5px to title vertical position
                              window_height=H_SIZE,
-                             window_width=W_SIZE
+                             window_width=W_SIZE,
+                             rect_width = 4
                              )
 timer_menu.add_option('Reset timer', reset_timer)
 
@@ -170,7 +171,9 @@ about_menu = pygameMenu.TextMenu(surface,
                                  text_fontsize=20,
                                  title='About',
                                  window_height=H_SIZE,
-                                 window_width=W_SIZE
+                                 window_width=W_SIZE,
+                                 text_centered=True,
+                                 draw_text_region_x=50
                                  )
 about_menu.add_option('Return to Menu', PYGAME_MENU_BACK)
 for m in ABOUT:
@@ -188,7 +191,9 @@ menu = pygameMenu.Menu(surface,
                        title='Main Menu',
                        title_offsety=5,
                        window_height=H_SIZE,
-                       window_width=W_SIZE
+                       window_width=W_SIZE,
+                       draw_region_x=5,
+                       menu_centered=False
                        )
 menu.add_option(timer_menu.get_title(), timer_menu)  # Add timer submenu
 menu.add_option(help_menu.get_title(), help_menu)  # Add help submenu

--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -601,10 +601,12 @@ class Menu(object):
                     for dy in range(len(self._actual._option)):
                         anchor = self._actual._get_option_anchor(dy)
                         if anchor.collidepoint(event.pos):
-                            changed = self._actual._index != dy
+                            curr_menu = self._actual
+                            curr_index = self._actual._index
                             self._actual._index = dy
                             self._select()
-                            if not changed:  # Click on selected option
+                            if curr_menu == self._actual and curr_index == self._actual._index:
+                                # Same menu displayed and click on selected option
                                 self._right()
                             if not self._actual._dopause:
                                 return True

--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -381,8 +381,10 @@ class Menu(object):
         Execute close callbacks and disable the menu.
         """
         onclose = self._actual._onclose
-        close = True
-        if not isinstance(onclose, type(None)):
+        if onclose is None:
+            close = False
+        else:
+            close = True
             a = isinstance(onclose, _locals.PymenuAction)
             b = str(type(onclose)) == _locals.PYGAMEMENU_PYMENUACTION
             if a or b:
@@ -397,8 +399,7 @@ class Menu(object):
                     close = False
             elif isinstance(onclose, (types.FunctionType, types.MethodType)):
                 onclose()
-        else:
-            close = False
+
         if close:
             self.disable()
         return close
@@ -458,7 +459,7 @@ class Menu(object):
 
             # If selected item then draw a rectangle
             if self._actual._drawselrect and (dy == self._actual._index):
-                _pygame.draw.rect(self._surface, self._actual._sel_color, anchor.inflate(16, 4), 1)
+                _pygame.draw.rect(self._surface, self._actual._sel_color, anchor.inflate(16, 4), self._rect_width)
 
     def enable(self):
         """

--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -458,7 +458,7 @@ class Menu(object):
 
             # If selected item then draw a rectangle
             if self._actual._drawselrect and (dy == self._actual._index):
-                _pygame.draw.rect(self._surface, self._actual._sel_color, anchor.inflate(20, 4), 1)
+                _pygame.draw.rect(self._surface, self._actual._sel_color, anchor.inflate(16, 4), 1)
 
     def enable(self):
         """
@@ -714,19 +714,8 @@ class Menu(object):
                 self.reset(1)
             # Close menu
             elif option == _locals.PYGAME_MENU_CLOSE:
-                self.disable()
+                self._close()
                 self._closelocked = False
-                closefun = self._actual._onclose
-                if closefun is not None:
-                    if closefun == _locals.PYGAME_MENU_RESET:
-                        self.reset(100)
-                    elif closefun == _locals.PYGAME_MENU_BACK:
-                        self.reset(1)
-                    elif closefun == _locals.PYGAME_MENU_EXIT:
-                        _pygame.quit()
-                        exit()
-                    elif isinstance(self._onclose, (types.FunctionType, types.MethodType)):
-                        closefun()
             # Exit program
             elif option == _locals.PYGAME_MENU_EXIT:
                 _pygame.quit()

--- a/pygameMenu/textmenu.py
+++ b/pygameMenu/textmenu.py
@@ -166,8 +166,8 @@ class TextMenu(Menu):
             ycoords = self._actual._opt_posy + self._actual._textdy + dy * (
                 self._actual._font_textsize + self._actual._textdy)
             ycoords -= self._actual._font_textsize / 2
-            self._surface.blit(text, (self._actual._pos_text_x + text_dx,
-                                      ycoords))
+
+            self._surface.blit(text, (self._actual._pos_text_x + text_dx, ycoords))
             dy += 1
 
     def _get_option_anchor(self, index):

--- a/pygameMenu/textmenu.py
+++ b/pygameMenu/textmenu.py
@@ -151,14 +151,7 @@ class TextMenu(Menu):
         :return: None
         """
         assert isinstance(self._actual, TextMenu)
-
-        # Draw background rectangle
-        _gfxdraw.filled_polygon(self._surface, self._actual._bgrect,
-                                self._actual._bgcolor)
-        # Draw title
-        _gfxdraw.filled_polygon(self._surface, self._actual._title_rect,
-                                self._bg_color_title)
-        self._surface.blit(self._actual._title, self._title_pos)
+        Menu.draw(self)
 
         # Draw text
         dy = 0
@@ -171,102 +164,28 @@ class TextMenu(Menu):
             else:
                 text_dx = 0
             ycoords = self._actual._opt_posy + self._actual._textdy + dy * (
-                    self._actual._font_textsize + self._actual._textdy)
+                self._actual._font_textsize + self._actual._textdy)
             ycoords -= self._actual._font_textsize / 2
             self._surface.blit(text, (self._actual._pos_text_x + text_dx,
                                       ycoords))
             dy += 1
-        dysum = dy * (self._actual._font_textsize + self._actual._textdy)
+
+    def _get_option_anchor(self, index):
+        """Get text Rect from the option index.
+        """
+        dysum = len(self._actual._text) * (self._actual._font_textsize + self._actual._textdy)
         dysum += 2 * self._actual._textdy + self._actual._font_textsize
 
-        dy = 0
-        dy_index = 0
-        for option in self._actual._option:
+        text, _ = self._get_option_texts(index)
+        text_width, text_height = text.get_size()
+        if self._actual._centered_option:
+            text_dx = -int(text_width / 2.0)
+        else:
+            text_dx = 0
+        t_dy = -int(text_height / 2.0)
 
-            # If option is selector
-            if option[0] == _locals.PYGAMEMENU_TYPE_SELECTOR:
-                # If selected index then change color
-                if dy == self._actual._index:
-                    text = self._actual._font.render(option[1].get(), 1,
-                                                     self._actual._sel_color)
-                    text_bg = self._actual._font.render(option[1].get(), 1,
-                                                        _cfg_menu.SHADOW_COLOR)
-                else:
-                    text = self._actual._font.render(option[1].get(), 1,
-                                                     self._actual._font_color)
-                    text_bg = self._actual._font.render(option[1].get(), 1,
-                                                        _cfg_menu.SHADOW_COLOR)
-            else:
-                # If selected index then change color
-                if dy == self._actual._index:
-                    text = self._actual._font.render(option[0], 1,
-                                                     self._actual._sel_color)
-                    text_bg = self._actual._font.render(option[0], 1,
-                                                        _cfg_menu.SHADOW_COLOR)
-                else:
-                    text = self._actual._font.render(option[0], 1,
-                                                     self._actual._font_color)
-                    text_bg = self._actual._font.render(option[0], 1,
-                                                        _cfg_menu.SHADOW_COLOR)
+        xccord = self._actual._opt_posx + text_dx
+        ycoord = self._actual._opt_posy + index * (self._actual._fsize + self._actual._opt_dy)\
+            + t_dy + dysum
 
-            # Text font and size
-            text_width, text_height = text.get_size()
-            if self._actual._centered_option:
-                text_dx = -int(text_width / 2.0)
-                t_dy = -int(text_height / 2.0)
-            else:
-                text_dx = 0
-                t_dy = 0
-
-            # Draw fonts
-            if self._actual._option_shadow:
-                ycoords = self._actual._opt_posy + dy * (
-                        self._actual._fsize + self._actual._opt_dy) + t_dy - 3
-                self._surface.blit(text_bg,
-                                   (self._actual._opt_posx + text_dx - 3,
-                                    ycoords + dysum))
-            ycoords = self._actual._opt_posy + dy * (
-                    self._actual._fsize + self._actual._opt_dy) + t_dy
-            self._surface.blit(text, (self._actual._opt_posx + text_dx,
-                                      ycoords + dysum))
-
-            # If selected option draw a rectangle
-            if self._actual._drawselrect and (dy_index == self._actual._index):
-                if not self._actual._centered_option:
-                    text_dx_tl = -text_width
-                else:
-                    text_dx_tl = text_dx
-                ycoords = self._actual._opt_posy + dy * (
-                        self._actual._fsize + self._actual._opt_dy) + t_dy - 2
-                _pygame.draw.line(self._surface, self._actual._sel_color, (
-                    self._actual._opt_posx + text_dx - 10,
-                    self._actual._opt_posy + dysum + dy * (
-                            self._actual._fsize + self._actual._opt_dy) + t_dy - 2),
-                                  ((self._actual._opt_posx - text_dx_tl + 10,
-                                    ycoords + dysum)), self._actual._rect_width)
-                ycoords = self._actual._opt_posy + dy * (
-                        self._actual._fsize + self._actual._opt_dy) - t_dy + 2
-                _pygame.draw.line(self._surface, self._actual._sel_color, (
-                    self._actual._opt_posx + text_dx - 10,
-                    self._actual._opt_posy + dysum + dy * (
-                            self._actual._fsize + self._actual._opt_dy) - t_dy + 2),
-                                  ((self._actual._opt_posx - text_dx_tl + 10,
-                                    ycoords + dysum)), self._actual._rect_width)
-                ycoords = self._actual._opt_posy + dy * (
-                        self._actual._fsize + self._opt_dy) - t_dy + 2
-                _pygame.draw.line(self._surface, self._actual._sel_color, (
-                    self._actual._opt_posx + text_dx - 10,
-                    self._actual._opt_posy + dysum + dy * (
-                            self._actual._fsize + self._actual._opt_dy) + t_dy - 2),
-                                  ((self._actual._opt_posx + text_dx - 10,
-                                    ycoords + dysum)), self._actual._rect_width)
-                ycoords = self._actual._opt_posy + dy * (
-                        self._actual._fsize + self._actual._opt_dy) - t_dy + 2
-                _pygame.draw.line(self._surface, self._actual._sel_color, (
-                    self._actual._opt_posx - text_dx_tl + 10,
-                    self._actual._opt_posy + dysum + dy * (
-                            self._actual._fsize + self._actual._opt_dy) + t_dy - 2),
-                                  ((self._actual._opt_posx - text_dx_tl + 10,
-                                    ycoords + dysum)), self._actual._rect_width)
-            dy += 1
-            dy_index += 1
+        return _pygame.Rect(xccord, ycoord, text_width, text_height)


### PR DESCRIPTION
This PR add the support to manage menu using a mouse:
* support is enabled by default (see param ``mouse_enabled``)
* click to select & change selectors
* click on top right corner to go back

Note: some code mutualisations have been performed, and tested using ``example.py`` and ``example2.py`` scripts. 