### PR TITLE
MenuBar with a cross for top menu

### DIFF
--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -316,6 +316,7 @@ class Menu(object):
                                  position=self._option_shadow_position,
                                  offset=self._option_shadow_offset)
         self._menubar.set_controls(self._joystick, self._mouse)
+        self._menubar.set_menu(self)
 
         # Selected option
         self._selected_inflate_x = 16
@@ -596,8 +597,7 @@ class Menu(object):
                           color=_cfg.MENU_SHADOW_COLOR,
                           position=self._option_shadow_position,
                           offset=self._option_shadow_offset)
-        widget.set_controls(self._joystick,
-                            self._mouse)
+        widget.set_controls(self._joystick, self._mouse)
         widget.set_alignment(align)
 
         # Store widget

--- a/pygameMenu/widgets/menubar.py
+++ b/pygameMenu/widgets/menubar.py
@@ -141,16 +141,31 @@ class MenuBar(Widget):
                                           self._polygon_pos[1][1] + 3,
                                           cross_size, cross_size)
 
-        self._backbox_pos = (
-            (self._backbox_rect.left + 5, self._backbox_rect.centery),
-            (self._backbox_rect.centerx, self._backbox_rect.top + 5),
-            (self._backbox_rect.centerx, self._backbox_rect.centery - 2),
-            (self._backbox_rect.right - 5, self._backbox_rect.centery - 2),
-            (self._backbox_rect.right - 5, self._backbox_rect.centery + 2),
-            (self._backbox_rect.centerx, self._backbox_rect.centery + 2),
-            (self._backbox_rect.centerx, self._backbox_rect.bottom - 5),
-            (self._backbox_rect.left + 5, self._backbox_rect.centery)
-        )
+        if not self._menu or not self._menu._top._prev:
+            # Make a cross for top menu
+            self._backbox_pos = (
+                (self._backbox_rect.left + 4, self._backbox_rect.top + 4),
+                (self._backbox_rect.centerx, self._backbox_rect.centery),
+                (self._backbox_rect.right - 4, self._backbox_rect.top + 4),
+                (self._backbox_rect.centerx, self._backbox_rect.centery),
+                (self._backbox_rect.right - 4, self._backbox_rect.bottom - 4),
+                (self._backbox_rect.centerx, self._backbox_rect.centery),
+                (self._backbox_rect.left + 4, self._backbox_rect.bottom - 4),
+                (self._backbox_rect.centerx, self._backbox_rect.centery),
+                (self._backbox_rect.left + 4, self._backbox_rect.top + 4),
+            )
+        else:
+            # Make a back arrow for sub-menus
+            self._backbox_pos = (
+                (self._backbox_rect.left + 5, self._backbox_rect.centery),
+                (self._backbox_rect.centerx, self._backbox_rect.top + 5),
+                (self._backbox_rect.centerx, self._backbox_rect.centery - 2),
+                (self._backbox_rect.right - 5, self._backbox_rect.centery - 2),
+                (self._backbox_rect.right - 5, self._backbox_rect.centery + 2),
+                (self._backbox_rect.centerx, self._backbox_rect.centery + 2),
+                (self._backbox_rect.centerx, self._backbox_rect.bottom - 5),
+                (self._backbox_rect.left + 5, self._backbox_rect.centery)
+            )
 
     def set_title(self, title, offsetx=0, offsety=0):
         """


### PR DESCRIPTION
Juste a small visual change.

I notice that I need to acmes to the private `_top` attribute outside of the `Menu` class which  not the best. However I'm little bit lost in the used of `_actual` and `_top` attributes. They seem to be used even if are not necessary.

For instance, I'm not sure that the use of `_actual` is necessary here, because the `clear()` method shall be applied on the correct menu:
```
    def clear(self):
        """
        Full reset menu and clear all widgets.

        :return: None
        """
        self.full_reset()
        del self._actual._option[:]
        del self._actual._submenus[:]
```

Should it be ?:

```
    def clear(self):
        """
        Full reset menu and clear all widgets.

        :return: None
        """
        self.full_reset()
        del self._option[:]
        del self._submenus[:]
```

More generally, the `_actual` attribute may be initialized to `None` and only set with the actual menu on the top menu instance?
