### PR TITLE
Cast to int to avoid DeprecationWarning

### DIFF
--- a/pygameMenu/examples/timer_clock.py
+++ b/pygameMenu/examples/timer_clock.py
@@ -276,8 +276,7 @@ def main(test=False):
         time_string = str(datetime.timedelta(seconds=int(timer[0])))
         time_blit = timer_font.render(time_string, 1, COLOR_WHITE)
         time_blit_size = time_blit.get_size()
-        surface.blit(time_blit, (
-            W_SIZE / 2 - time_blit_size[0] / 2, H_SIZE / 2 - time_blit_size[1] / 2))
+        surface.blit(time_blit, (int(W_SIZE / 2 - time_blit_size[0] / 2), int(H_SIZE / 2 - time_blit_size[1] / 2)))
 
         # Execute main from principal menu if is enabled
         main_menu.mainloop(events, disable_loop=test)


### PR DESCRIPTION
Cast to int to avoid the following warning:
```
DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
  surface.blit(time_blit, (W_SIZE / 2 - time_blit_size[0] / 2, H_SIZE / 2 - time_blit_size[1] / 2))
```