### PR TITLE
Fix mainloop to not break until menu is closed + add example

### DIFF
--- a/pygameMenu/examples/simple.py
+++ b/pygameMenu/examples/simple.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+"""
+pygame-menu
+https://github.com/ppizarror/pygame-menu
+
+EXAMPLE - GAME SELECTOR
+Game with 3 difficulty options.
+
+License:
+-------------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright 2017-2020 Pablo Pizarro R. @ppizarror
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+-------------------------------------------------------------------------------
+"""
+
+import os
+import pygame
+import pygameMenu
+
+
+pygame.init()
+os.environ['SDL_VIDEO_CENTERED'] = '1'
+surface = pygame.display.set_mode((600, 500))
+
+
+def set_difficulty(selected, value):
+    print("Set difficulty to {} ({})".format(selected[0], value))
+
+
+def start_the_game():
+    print("Do the job here !")
+
+
+menu = pygameMenu.Menu(300, 400, pygameMenu.font.FONT_BEBAS, "Welcome",
+                       widget_font_color=(102, 122, 130),
+                       selection_color=(207, 62, 132),
+                       title_font_color=(38, 158, 151),
+                       title_background_color=(4, 47, 58),
+                       menu_background_color=(239, 231, 211))
+
+menu.add_text_input('Name: ')
+menu.add_selector('Difficulty: ', [('Hard', 1), ('Easy', 2)], onchange=set_difficulty)
+menu.add_button('Play', start_the_game)
+menu.add_button('Quit', pygameMenu.events.EXIT)
+menu.center_content()
+
+menu.mainloop(surface, fps_limit=30)

--- a/pygameMenu/examples/simple.py
+++ b/pygameMenu/examples/simple.py
@@ -61,4 +61,4 @@ menu.add_button('Play', start_the_game)
 menu.add_button('Quit', pygameMenu.events.EXIT)
 menu.center_content()
 
-menu.mainloop(surface, fps_limit=30)
+menu.mainloop(surface)

--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -1394,7 +1394,7 @@ class Menu(object):
 
         return updated
 
-    def mainloop(self, surface, bgfun, event_loop=None, disable_loop=False, fps_limit=0):
+    def mainloop(self, surface, bgfun=None, disable_loop=False, fps_limit=0):
         """
         Main loop of Menu. In this function, the Menu handle exceptions and draw.
         The Menu pauses the application and checks :py:mod:`pygame` events itself.
@@ -1412,8 +1412,6 @@ class Menu(object):
         :type surface: pygame.surface.SurfaceType
         :param bgfun: Background function called on each loop iteration before drawing the Menu
         :type bgfun: callable
-        :param event_loop: Events used by the loop if Menu was created using mainloop_loop=False
-        :type event_loop: list, NoneType
         :param disable_loop: If true run this method for only 1 loop
         :type disable_loop: bool
         :param fps_limit: Limit frame per second of the loop, if 0 there's no limit
@@ -1421,8 +1419,8 @@ class Menu(object):
         :return: None
         """
         assert isinstance(surface, _pygame.Surface)
-        assert callable(bgfun), 'background function must be callable (a function)'
-        assert isinstance(event_loop, (list, type(None)))
+        if bgfun:
+            assert callable(bgfun), 'background function must be callable (a function)'
         assert isinstance(disable_loop, bool)
         assert isinstance(fps_limit, (int, float))
         assert fps_limit >= 0, 'fps limit cannot be negative'
@@ -1437,14 +1435,14 @@ class Menu(object):
 
             # If loop, gather events by Menu and draw the background function, if this method
             # returns true then the mainloop will break
-            updated = self.update(_pygame.event.get())
+            self.update(_pygame.event.get())
 
             # As event can change the status of the Menu, this has to be checked twice
             if self.is_enabled():
                 self.draw(surface=surface)
 
             _pygame.display.flip()
-            if updated or disable_loop:
+            if not self.is_enabled() or disable_loop:
                 self._current._background_function = None
                 return
 

--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -1394,7 +1394,7 @@ class Menu(object):
 
         return updated
 
-    def mainloop(self, surface, bgfun=None, disable_loop=False, fps_limit=0):
+    def mainloop(self, surface, bgfun=None, disable_loop=False, fps_limit=30):
         """
         Main loop of Menu. In this function, the Menu handle exceptions and draw.
         The Menu pauses the application and checks :py:mod:`pygame` events itself.

--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -1248,7 +1248,7 @@ class Menu(object):
         if self._joy_event & _JOY_EVENT_RIGHT:
             self._right()
 
-    def update(self, events=None):
+    def update(self, events):
         """
         Update the status of the Menu using external events.
         The update event is applied only on the current Menu.
@@ -1442,6 +1442,7 @@ class Menu(object):
                 self.draw(surface=surface)
 
             _pygame.display.flip()
+
             if not self.is_enabled() or disable_loop:
                 self._current._background_function = None
                 return

--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -1171,8 +1171,8 @@ class Menu(object):
             self._current._build_widget_surface()
 
         # Fill the surface with background function (setted from mainloop)
-        if self._current._background_function is not None:
-            self._current._background_function()
+        if self._top._background_function is not None:
+            self._top._background_function()
 
         # Fill the scrolling surface
         self._current._widgets_surface.fill((255, 255, 255, 0))
@@ -1429,7 +1429,8 @@ class Menu(object):
         if not self.is_enabled():
             return
 
-        self._current._background_function = bgfun
+        self._background_function = bgfun
+
         while True:
             self._current._clock.tick(fps_limit)
 
@@ -1444,7 +1445,7 @@ class Menu(object):
             _pygame.display.flip()
 
             if not self.is_enabled() or disable_loop:
-                self._current._background_function = None
+                self._background_function = None
                 return
 
     def get_input_data(self, recursive=False, current=True):


### PR DESCRIPTION
I change the `mainloop()` in order to not check the `updated` state otherwise the loop was broken at first event used.

I also add the most simple example of a menu, the idea is to describe this code in the documentation and to keep it as simple as possible to show how it is cool to make a menu with `pygame-menu`.