### PR TITLE
Make wheel as universal (compatible py2 and py3)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,9 +78,15 @@ setup(name='pygame-menu',
           ],
       include_package_data=True,
       packages=find_packages(exclude=['test']),
+      python_requires='>=2.7',
       install_requires=requirements,
       extras_require={
                         'doc': ['sphinx', 'sphinx-rtd-theme'],
-                     },
-      python_requires='>=2.7',
+                    },
+      setup_requires=[
+                        'setuptools',
+                    ],
+      options={
+                        'bdist_wheel': {'universal': True}
+                },
       )


### PR DESCRIPTION
I noticed that the v2.3.1 have no `.whl` for python2