### PR TITLE
Add mousemotion check.

### DIFF
--- a/pygameMenu/menu.py
+++ b/pygameMenu/menu.py
@@ -1412,6 +1412,12 @@ class Menu(object):
                         updated = True  # It is updated
                         break
 
+                elif self._current._mouse and event.type == pygame.MOUSEMOTION:
+                    for index in range(len(self._current._widgets)):
+                        widget = self._current._widgets[index]
+                        if self._current._scroll.to_real_position(widget.get_rect()).collidepoint(*event.pos):
+                            self._current._select(index)
+
         # Check if the position has changed
         if len(self._current._widgets) > 0:
             menu_surface_needs_update = menu_surface_needs_update or self._current._widgets[


### PR DESCRIPTION
If mouse in menu is enabled, buttons can't be selected when hover cursor over them. In my opinion, this is not very convenient when you need to create a menu that fully supports the mouse.

Test code:
```
import pygame
import pygameMenu


pygame.init()
surface = pygame.display.set_mode((600, 400))

def set_difficulty(value, difficulty):
    pass

def start_the_game():
    pass

menu = pygameMenu.menu.Menu(300, 400, "Welcome", theme=pygameMenu.themes.THEME_BLUE)

menu.add_text_input('Name :', default='John Doe')
menu.add_selector('Difficulty :', [('Hard', 1), ('Easy', 2)], onchange=set_difficulty)
menu.add_button('Play', start_the_game)
menu.add_button('Quit', pygameMenu.events.EXIT)
menu.center_content()

menu.mainloop(surface)
```

See  the result [here](https://i.imgur.com/bWSZaw4.gif)