### PR TITLE
Add widget focus

### DIFF
--- a/docs/_source/themes.rst
+++ b/docs/_source/themes.rst
@@ -30,12 +30,12 @@ Several predefined themes are proposed by :py:mod:`pygame-menu`.
 ==============================================  ================================================
 Theme name                                      Example
 ==============================================  ================================================
-:py:data:`pygame_menu.themes.THEME_DEFAULT`      .. image:: ../_static/theme_default.png
-:py:data:`pygame_menu.themes.THEME_BLUE`         .. image:: ../_static/theme_blue.png
-:py:data:`pygame_menu.themes.THEME_DARK`         .. image:: ../_static/theme_dark.png
-:py:data:`pygame_menu.themes.THEME_GREEN`        .. image:: ../_static/theme_green.png
-:py:data:`pygame_menu.themes.THEME_ORANGE`       .. image:: ../_static/theme_orange.png
-:py:data:`pygame_menu.themes.THEME_SOLARIZED`    .. image:: ../_static/theme_solarized.png
+:py:data:`pygame_menu.themes.THEME_DEFAULT`     .. image:: ../_static/theme_default.png
+:py:data:`pygame_menu.themes.THEME_BLUE`        .. image:: ../_static/theme_blue.png
+:py:data:`pygame_menu.themes.THEME_DARK`        .. image:: ../_static/theme_dark.png
+:py:data:`pygame_menu.themes.THEME_GREEN`       .. image:: ../_static/theme_green.png
+:py:data:`pygame_menu.themes.THEME_ORANGE`      .. image:: ../_static/theme_orange.png
+:py:data:`pygame_menu.themes.THEME_SOLARIZED`   .. image:: ../_static/theme_solarized.png
 ==============================================  ================================================
 
 

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -1044,7 +1044,7 @@ class Menu(object):
         max_x = -1e6
         max_y = -1e6
         for widget in self._widgets:  # type: _widgets.core.Widget
-            _, _, x, y = widget.get_position()  # Use only bottom right position
+            _, _, x, y = widget.get_relative_position()  # Use only bottom right position
             max_x = max(max_x, x)
             max_y = max(max_y, y)
         return max_x, max_y
@@ -1236,10 +1236,21 @@ class Menu(object):
         for widget in self._current._widgets:  # type: _widgets.core.Widget
             widget.draw(self._current._widgets_surface)
             if widget.selected:
+                print(widget.get_absolute_position(self._current._scroll))
                 widget.draw_selected_rect(self._current._widgets_surface)
 
         self._current._scroll.draw(surface)
         self._current._menubar.draw(surface)
+
+    def _draw_focus(self, widget):
+        """
+        Draw the focus background from a given widget.
+
+        :param widget: Focused widget
+        :type widget: :py:class:`pygame_menu.widgets.core.widget.Widget`
+        :return: None
+        """
+        return
 
     def enable(self):
         """

--- a/pygame_menu/scrollarea.py
+++ b/pygame_menu/scrollarea.py
@@ -106,8 +106,13 @@ class ScrollArea(object):
         assert_color(shadow_color)
         assert_position(shadow_position)
 
+        assert area_width > 0 and area_height > 0, \
+            'area size must be greater than zero'
+
+        self._area_width = area_width
+        self._area_height = area_height
         self._rect = pygame.Rect(0.0, 0.0, area_width, area_height)
-        self._world = world
+        self._world = world  # type: pygame.Surface
         self._scrollbars = []
         self._scrollbar_positions = tuple(set(scrollbars))  # Ensure unique
         self._scrollbar_thick = scrollbar_thick
@@ -233,6 +238,35 @@ class ScrollArea(object):
         if not self._world:
             return 0
         return max(0, self._world.get_height() - self._view_rect.height)
+
+    def get_position(self):
+        """
+        Return the position of the scroll.
+
+        :return: Position (x,y)
+        :rtype: tuple
+        """
+        return self._rect.x, self._rect.y
+
+    def get_world_size(self):
+        """
+        Return world size.
+
+        :return: width, height in pixels
+        :rtype: tuple
+        """
+        if self._world is None:
+            return 0, 0
+        return self._world.get_width(), self._world.get_height()
+
+    def get_area_size(self):
+        """
+        Return the area size.
+
+        :return: width, height in pixels
+        :rtype: tuple
+        """
+        return self._area_width, self._area_height
 
     def get_offsets(self):
         """

--- a/pygame_menu/themes.py
+++ b/pygame_menu/themes.py
@@ -57,6 +57,8 @@ class Theme(object):
     :type cursor_color: tuple, list
     :param cursor_selection_color: Selection box color
     :type cursor_selection_color: tuple, list
+    :param focus_background_color: Color of the widget focus, this must be a tuple of 4 elements. And must be transparent
+    :type focus_background_color: tuple, list
     :param scrollbar_color: Scrollbars color
     :type scrollbar_color: tuple, list
     :param scrollbar_shadow: Indicate if a shadow is drawn on each scrollbar
@@ -128,6 +130,8 @@ class Theme(object):
                                       'color', (0, 0, 0))  # type: tuple
         self.cursor_selection_color = self._get(kwargs, 'cursor_selection_color',
                                                 'color', (30, 30, 30))  # type: tuple
+        self.focus_background_color = self._get(kwargs, 'focus_background_color',
+                                                'color', (0, 0, 0, 150))  # type: tuple
         self.scrollbar_color = self._get(kwargs, 'scrollbar_color',
                                          'color', (220, 220, 220))  # type: tuple
         self.scrollbar_shadow = self._get(kwargs, 'scrollbar_shadow',
@@ -208,6 +212,8 @@ class Theme(object):
 
         :return: None
         """
+
+        # Size asserts
         assert self.scrollbar_thick > 0, 'scrollbar thickness must be greater than zero'
         assert self.scrollbar_shadow_offset > 0, 'scrollbar shadow offset must be greater than zero'
         assert self.title_font_size > 0, 'title font size must be greater than zero'
@@ -218,6 +224,7 @@ class Theme(object):
 
         # Format colors, this converts all color lists to tuples automatically
         self.background_color = self._format_opacity(self.background_color)
+        self.focus_background_color = self._format_opacity(self.focus_background_color)
         self.scrollbar_color = self._format_opacity(self.scrollbar_color)
         self.scrollbar_shadow_color = self._format_opacity(self.scrollbar_shadow_color)
         self.scrollbar_slider_color = self._format_opacity(self.scrollbar_slider_color)
@@ -235,6 +242,10 @@ class Theme(object):
 
         # Configs
         self.widget_selection_effect.set_color(self.selection_color)
+
+        # Color asserts
+        assert self.focus_background_color[3] != 255, \
+            'focus background color cannot be fully opaque, suggested opacity between 0 and 200'
 
     @staticmethod
     def _vec_2tuple(obj):

--- a/pygame_menu/themes.py
+++ b/pygame_menu/themes.py
@@ -131,7 +131,7 @@ class Theme(object):
         self.cursor_selection_color = self._get(kwargs, 'cursor_selection_color',
                                                 'color', (30, 30, 30))  # type: tuple
         self.focus_background_color = self._get(kwargs, 'focus_background_color',
-                                                'color', (0, 0, 0, 150))  # type: tuple
+                                                'color', (0, 0, 0, 180))  # type: tuple
         self.scrollbar_color = self._get(kwargs, 'scrollbar_color',
                                          'color', (220, 220, 220))  # type: tuple
         self.scrollbar_shadow = self._get(kwargs, 'scrollbar_shadow',
@@ -244,8 +244,8 @@ class Theme(object):
         self.widget_selection_effect.set_color(self.selection_color)
 
         # Color asserts
-        assert self.focus_background_color[3] != 255, \
-            'focus background color cannot be fully opaque, suggested opacity between 0 and 200'
+        assert self.focus_background_color[3] != 0, \
+            'focus background color cannot be fully transparent, suggested opacity between 1 and 255'
 
     @staticmethod
     def _vec_2tuple(obj):

--- a/pygame_menu/widgets/core/widget.py
+++ b/pygame_menu/widgets/core/widget.py
@@ -125,10 +125,11 @@ class Widget(object):
         self._selection_effect = None  # type: Selection
 
         # Public attributes
+        self.active = True  # Widget requests focus
         self.is_selectable = True  # Some widgets cannot be selected like labels
-        self.joystick_enabled = True  # type: bool
-        self.mouse_enabled = True  # type: bool
-        self.selected = False  # type: bool
+        self.joystick_enabled = True
+        self.mouse_enabled = True
+        self.selected = False
         self.sound = Sound()  # type: Sound
 
     @staticmethod
@@ -282,9 +283,9 @@ class Widget(object):
         """
         raise NotImplementedError('override is mandatory')
 
-    def draw_selected_rect(self, surface):
+    def draw_selection(self, surface):
         """
-        Draw selected rect around widget.
+        Draw selection effect on widget.
 
         :param surface: Surface to draw
         :type surface: :py:class:`pygame.Surface`
@@ -540,7 +541,7 @@ class Widget(object):
 
     def get_absolute_position(self, scroll_area):
         """
-        Return the absolute position in the screen considering the widget is in the given scroll.
+        Return the absolute position in the scroll area considering the widget is in the given scroll.
         The position will not exceed the height of the scroll area.
 
         :param scroll_area: Sroll parent of the widget
@@ -555,13 +556,25 @@ class Widget(object):
         # .------------(x2,y2)
         #
         # This coordinates are added to the position of the scroll area (x0,y0)
+
+        # Add selected margin
+        t, l, b, r = 0, 0, 0, 0  # top, left, bottom, right
+        if self.selected and self._selection_effect is not None:
+            t, l, b, r = self._selection_effect.get_margin()
+
         offx, offy = scroll_area.get_offsets()
         w, h = scroll_area.get_area_size()
+
+        # Add scrollbar if enabled
+        w -= scroll_area.get_scrollbar_thickness(_locals.ORIENTATION_VERTICAL)
+        h -= scroll_area.get_scrollbar_thickness(_locals.ORIENTATION_HORIZONTAL)
+
         x0, y0 = scroll_area.get_position()
-        x1 = int(min(max(self._rect.x - offx, 0), w)) + x0
-        x2 = int(min(max(self._rect.x + self._rect.width - offx, 0), w)) + x0
-        y1 = int(min(max(self._rect.y - offy, 0), h)) + y0
-        y2 = int(min(max(self._rect.y + self._rect.height - offy, 0), h)) + y0
+        x1 = int(min(max(self._rect.x - l - offx, 0), w)) + x0
+        x2 = int(min(max(self._rect.x + r + self._rect.width - offx, 0), w)) + x0
+        y1 = int(min(max(self._rect.y - t - offy, 0), h)) + y0
+        y2 = int(min(max(self._rect.y + b + self._rect.height - offy, 0), h)) + y0
+
         return x1, y1, x2, y2
 
     def set_alignment(self, align):

--- a/pygame_menu/widgets/core/widget.py
+++ b/pygame_menu/widgets/core/widget.py
@@ -125,7 +125,7 @@ class Widget(object):
         self._selection_effect = None  # type: Selection
 
         # Public attributes
-        self.active = True  # Widget requests focus
+        self.active = False  # Widget requests focus
         self.is_selectable = True  # Some widgets cannot be selected like labels
         self.joystick_enabled = True
         self.mouse_enabled = True

--- a/pygame_menu/widgets/core/widget.py
+++ b/pygame_menu/widgets/core/widget.py
@@ -528,15 +528,41 @@ class Widget(object):
         self._rect.y = posy
         self._last_selected_surface = None
 
-    def get_position(self):
+    def get_relative_position(self):
         """
         Return a tuple containing the top left and bottom right positions in
         the format of (x leftmost, y uppermost, x rightmost, y lowermost).
 
-        :return: Tuple of 4 elements
+        :return: Tuple of 4 elements, *(x leftmost, y uppermost, x rightmost, y lowermost)*
         :rtype: tuple
         """
         return self._rect.x, self._rect.y, self._rect.x + self._rect.width, self._rect.y + self._rect.height
+
+    def get_absolute_position(self, scroll_area):
+        """
+        Return the absolute position in the screen considering the widget is in the given scroll.
+        The position will not exceed the height of the scroll area.
+
+        :param scroll_area: Sroll parent of the widget
+        :type scroll_area: :py:class:`pygame_menu.scrollarea.ScrollArea`
+        :return: Tuple of 4 elements, *(x leftmost, y uppermost, x rightmost, y lowermost)*
+        :rtype: tuple
+        """
+        # This method performs the calculation of the following coordinates:
+        #
+        # (x1,y1) ----------.
+        # |                 |
+        # .------------(x2,y2)
+        #
+        # This coordinates are added to the position of the scroll area (x0,y0)
+        offx, offy = scroll_area.get_offsets()
+        w, h = scroll_area.get_area_size()
+        x0, y0 = scroll_area.get_position()
+        x1 = int(min(max(self._rect.x - offx, 0), w)) + x0
+        x2 = int(min(max(self._rect.x + self._rect.width - offx, 0), w)) + x0
+        y1 = int(min(max(self._rect.y - offy, 0), h)) + y0
+        y2 = int(min(max(self._rect.y + self._rect.height - offy, 0), h)) + y0
+        return x1, y1, x2, y2
 
     def set_alignment(self, align):
         """

--- a/pygame_menu/widgets/widget/menubar.py
+++ b/pygame_menu/widgets/widget/menubar.py
@@ -35,6 +35,7 @@ import pygame
 import pygame.gfxdraw as gfxdraw
 import pygame_menu.controls as _controls
 from pygame_menu.widgets.core import Widget
+from pygame_menu.utils import assert_color
 
 MENUBAR_STYLE_ADAPTIVE = 1000
 MENUBAR_STYLE_SIMPLE = 1001
@@ -53,6 +54,8 @@ class MenuBar(Widget):
     :type label: str
     :param width: Width of the widget, generally width of the Menu
     :type width: int, float
+    :param background_color: Background color
+    :type background_color: tuple, list
     :param back_box: Draw a back-box button on header
     :type back_box: bool
     :param mode: Mode of drawing the bar
@@ -68,6 +71,7 @@ class MenuBar(Widget):
     def __init__(self,
                  label,
                  width,
+                 background_color,
                  back_box=False,
                  mode=MENUBAR_STYLE_ADAPTIVE,
                  onchange=None,
@@ -77,6 +81,7 @@ class MenuBar(Widget):
         assert isinstance(label, str)
         assert isinstance(width, (int, float))
         assert isinstance(back_box, bool)
+        assert_color(background_color)
 
         # MenuBar has no ID
         super(MenuBar, self).__init__(onchange=onchange,
@@ -84,6 +89,7 @@ class MenuBar(Widget):
                                       args=args,
                                       kwargs=kwargs)
 
+        self._background_color = background_color
         self._backbox = back_box
         self._backbox_pos = None  # type: (tuple,None)
         self._backbox_rect = None  # type: (pygame.rect.Rect,None)
@@ -102,7 +108,7 @@ class MenuBar(Widget):
         self._render()
 
         if len(self._polygon_pos) > 2:
-            gfxdraw.filled_polygon(surface, self._polygon_pos, self._font_color)
+            gfxdraw.filled_polygon(surface, self._polygon_pos, self._background_color)
 
         if self.mouse_enabled and self._backbox:
             pygame.draw.rect(surface, self._font_selected_color, self._backbox_rect, 1)
@@ -116,7 +122,7 @@ class MenuBar(Widget):
         """
         Return the title of the Menu.
 
-        :return: Title
+        :return: Menu title
         :rtype: str
         """
         return self._label


### PR DESCRIPTION
As discussed in #171 this PR introduces `Menu._draw_focus_widget()` method if a widget is active.

![timer_clock](https://user-images.githubusercontent.com/12925256/79717090-a5703e00-82a6-11ea-8872-9f9454531173.gif)
