### PR TITLE
Remove duplicated methods between widget and scroll area

### DIFF
--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -1047,7 +1047,7 @@ class Menu(object):
             for r in range(row):
                 rwidget = self._widgets[int(self._rows * col + r)]  # type: _widgets.core.Widget
                 ysum += widget_rects[rwidget.get_id()].height + rwidget.get_margin()[1]
-            y_coord = self._widget_offset[1] + ysum + sel_bottom
+            y_coord = max(1, self._widget_offset[1]) + ysum + sel_bottom
 
             # Update the position of the widget
             widget.set_position(x_coord, y_coord)

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -1062,7 +1062,7 @@ class Menu(object):
         max_x = -1e6
         max_y = -1e6
         for widget in self._widgets:  # type: _widgets.core.Widget
-            _, _, x, y = widget.get_relative_position()  # Use only bottom right position
+            x, y = widget.get_rect().bottomright
             max_x = max(max_x, x)
             max_y = max(max_y, y)
         return max_x, max_y
@@ -1277,7 +1277,13 @@ class Menu(object):
         if widget is None or not widget.active or not self._mouse_motion_selection:
             return
         window_width, window_height = pygame.display.get_surface().get_size()
-        x1, y1, x2, y2 = widget.get_absolute_position(self._current._scroll)
+
+        rect = widget.get_rect()
+        if widget.selected and widget.get_selection_effect():
+            rect = widget.get_selection_effect().inflate(rect)
+        rect = self._current._scroll.to_real_position(rect)
+
+        x1, y1, x2, y2 = rect.topleft + rect.bottomright
 
         # Convert to integer
         x1 = int(x1)

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -1281,7 +1281,7 @@ class Menu(object):
         rect = widget.get_rect()
         if widget.selected and widget.get_selection_effect():
             rect = widget.get_selection_effect().inflate(rect)
-        rect = self._current._scroll.to_real_position(rect)
+        rect = self._current._scroll.to_real_position(rect, visible=True)
 
         x1, y1, x2, y2 = rect.topleft + rect.bottomright
 

--- a/pygame_menu/scrollarea.py
+++ b/pygame_menu/scrollarea.py
@@ -474,7 +474,8 @@ class ScrollArea(object):
 
         :param virtual: Position/Rect in the world surface reference
         :type virtual: :py:class:`pygame.Rect`, tuple, list
-        :return: None
+        :return: real rect or real position
+        :rtype: :py:class:`pygame.Rect`, tuple
         """
         assert isinstance(virtual, (pygame.Rect, tuple, list))
         offsets = self.get_offsets()
@@ -496,7 +497,8 @@ class ScrollArea(object):
 
         :param real: Position/Rect according scroll area origin
         :type real: :py:class:`pygame.Rect`, tuple, list
-        :return: None
+        :return: rect in world or position in world
+        :rtype: :py:class:`pygame.Rect`, tuple
         """
         assert isinstance(real, (pygame.Rect, tuple, list))
         offsets = self.get_offsets()

--- a/pygame_menu/scrollarea.py
+++ b/pygame_menu/scrollarea.py
@@ -467,13 +467,15 @@ class ScrollArea(object):
         self._world = surface
         self._apply_size_changes()
 
-    def to_real_position(self, virtual):
+    def to_real_position(self, virtual, visible=False):
         """
         Return the real position/Rect according to the scroll area origin
         of a position/Rect in the world surface reference.
 
         :param virtual: Position/Rect in the world surface reference
         :type virtual: :py:class:`pygame.Rect`, tuple, list
+        :param visible: If a rect is given, return only the visible width/height
+        :type visible: bool
         :return: real rect or real position
         :rtype: :py:class:`pygame.Rect`, tuple
         """
@@ -484,6 +486,8 @@ class ScrollArea(object):
             rect = pygame.Rect(virtual)
             rect.x = self._rect.x + virtual.x - offsets[0]
             rect.y = self._rect.y + virtual.y - offsets[1]
+            if visible:
+                return self._view_rect.clip(rect)  # Visible width and height
             return rect
 
         x_coord = self._rect.x + virtual[0] - offsets[0]

--- a/pygame_menu/scrollarea.py
+++ b/pygame_menu/scrollarea.py
@@ -109,8 +109,6 @@ class ScrollArea(object):
         assert area_width > 0 and area_height > 0, \
             'area size must be greater than zero'
 
-        self._area_width = area_width
-        self._area_height = area_height
         self._rect = pygame.Rect(0.0, 0.0, area_width, area_height)
         self._world = world  # type: pygame.Surface
         self._scrollbars = []
@@ -239,35 +237,6 @@ class ScrollArea(object):
             return 0
         return max(0, self._world.get_height() - self._view_rect.height)
 
-    def get_position(self):
-        """
-        Return the position of the scroll.
-
-        :return: Position (x,y)
-        :rtype: tuple
-        """
-        return self._rect.x, self._rect.y
-
-    def get_world_size(self):
-        """
-        Return world size.
-
-        :return: width, height in pixels
-        :rtype: tuple
-        """
-        if self._world is None:
-            return 0, 0
-        return self._world.get_width(), self._world.get_height()
-
-    def get_area_size(self):
-        """
-        Return the area size.
-
-        :return: width, height in pixels
-        :rtype: tuple
-        """
-        return self._area_width, self._area_height
-
     def get_offsets(self):
         """
         Return the offset introduced by the scrollbars in the world.
@@ -291,7 +260,22 @@ class ScrollArea(object):
         :return: Pygame.Rect object
         :rtype: :py:class:`pygame.Rect`
         """
-        return self._rect
+        return self._rect.copy()
+
+    def get_scrollbar_thickness(self, orientation):
+        """
+        Return the scroll thickness of the area. If it's hidden return zero.
+
+        :param orientation: Orientation of the scroll
+        :type orientation: str
+        :return: Thickness in px
+        :rtype: int
+        """
+        if orientation == _locals.ORIENTATION_HORIZONTAL:
+            return self._rect.height - self._view_rect.height
+        elif orientation == _locals.ORIENTATION_VERTICAL:
+            return self._rect.width - self._view_rect.width
+        return 0
 
     def get_view_rect(self):
         """
@@ -365,20 +349,16 @@ class ScrollArea(object):
 
         return rect
 
-    def get_scrollbar_thickness(self, orientation):
+    def get_world_size(self):
         """
-        Return the scroll thickness of the area. If it's hidden return zero.
+        Return world size.
 
-        :param orientation: Orientation of the scroll
-        :type orientation: str
-        :return: Thickness in px
-        :rtype: int
+        :return: width, height in pixels
+        :rtype: tuple
         """
-        if orientation == _locals.ORIENTATION_HORIZONTAL:
-            return self._rect.height - self._view_rect.height
-        elif orientation == _locals.ORIENTATION_VERTICAL:
-            return self._rect.width - self._view_rect.width
-        return 0
+        if self._world is None:
+            return 0, 0
+        return self._world.get_width(), self._world.get_height()
 
     def _on_horizontal_scroll(self, value):
         """

--- a/pygame_menu/widgets/core/selection.py
+++ b/pygame_menu/widgets/core/selection.py
@@ -30,6 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 -------------------------------------------------------------------------------
 """
 
+import pygame
 from pygame_menu.utils import assert_color
 
 
@@ -87,6 +88,19 @@ class Selection(object):
         """
         _, l, _, r = self.get_margin()
         return l + r
+
+    def inflate(self, rect):
+        """
+        Grow or shrink the rectangle size according to margins.
+
+        :param rect: rectangle
+        :type rect: :py:class:`pygame.Rect`
+        """
+        assert isinstance(rect, pygame.Rect)
+        return pygame.Rect(rect.x - self.margin_left,
+                           rect.y - self.margin_top,
+                           rect.width + self.margin_left + self.margin_right,
+                           rect.height + self.margin_top + self.margin_bottom)
 
     def get_height(self):
         """

--- a/pygame_menu/widgets/core/widget.py
+++ b/pygame_menu/widgets/core/widget.py
@@ -525,54 +525,6 @@ class Widget(object):
         self._rect.x = posx
         self._rect.y = posy
 
-    def get_relative_position(self):
-        """
-        Return a tuple containing the top left and bottom right positions in
-        the format of (x leftmost, y uppermost, x rightmost, y lowermost).
-
-        :return: Tuple of 4 elements, *(x leftmost, y uppermost, x rightmost, y lowermost)*
-        :rtype: tuple
-        """
-        return self._rect.x, self._rect.y, self._rect.x + self._rect.width, self._rect.y + self._rect.height
-
-    def get_absolute_position(self, scroll_area):
-        """
-        Return the absolute position in the scroll area considering the widget is in the given scroll.
-        The position will not exceed the height of the scroll area.
-
-        :param scroll_area: Sroll parent of the widget
-        :type scroll_area: :py:class:`pygame_menu.scrollarea.ScrollArea`
-        :return: Tuple of 4 elements, *(x leftmost, y uppermost, x rightmost, y lowermost)*
-        :rtype: tuple
-        """
-        # This method performs the calculation of the following coordinates:
-        #
-        # (x1,y1) ----------.
-        # |                 |
-        # .------------(x2,y2)
-        #
-        # This coordinates are added to the position of the scroll area (x0,y0)
-
-        # Add selected margin
-        t, l, b, r = 0, 0, 0, 0  # top, left, bottom, right
-        if self.selected and self._selection_effect is not None:
-            t, l, b, r = self._selection_effect.get_margin()
-
-        offx, offy = scroll_area.get_offsets()
-        w, h = scroll_area.get_area_size()
-
-        # Add scrollbar if enabled
-        w -= scroll_area.get_scrollbar_thickness(_locals.ORIENTATION_VERTICAL)
-        h -= scroll_area.get_scrollbar_thickness(_locals.ORIENTATION_HORIZONTAL)
-
-        x0, y0 = scroll_area.get_position()
-        x1 = min(max(self._rect.x - l - offx, 0), w) + x0
-        x2 = min(max(self._rect.x + r + self._rect.width - offx, 0), w) + x0
-        y1 = min(max(self._rect.y - t - offy, 0), h) + y0
-        y2 = min(max(self._rect.y + b + self._rect.height - offy, 0), h) + y0
-
-        return x1, y1, x2, y2
-
     def set_alignment(self, align):
         """
         Set the alignment of the widget.

--- a/pygame_menu/widgets/selection/highlight.py
+++ b/pygame_menu/widgets/selection/highlight.py
@@ -61,12 +61,10 @@ class HighlightSelection(Selection):
                                                  margin_top=margin_y / 2 + border_width,
                                                  margin_bottom=margin_y / 2 + border_width)
         self._border_width = border_width
-        self._margin_x = margin_x
-        self._margin_y = margin_y
 
     # noinspection PyMissingOrEmptyDocstring
     def draw(self, surface, widget):
         pygame.draw.rect(surface,
                          self.color,
-                         widget.get_rect().inflate(self._margin_x, self._margin_y),
+                         self.inflate(widget.get_rect()),
                          self._border_width)


### PR DESCRIPTION
Changing the referential of a widget is already implemented in the scroll area it-self.

I  think it should stay managed by the scroll area because it is the container of all the widgets. Thus it is aware about all positions and geometries.