### PR TITLE
Allow the end-user to set the screen-dimensions explicitly rather than querying pygame.display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 cache: pip
 
 # Pip installs

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ pygame-menu
     :target: https://opensource.org/licenses/MIT
     :alt: License MIT
 
-.. image:: https://img.shields.io/badge/python-2.7+ / 3.4+-red.svg
+.. image:: https://img.shields.io/badge/python-2.7+ / 3.5+-red.svg
     :target: https://www.python.org/downloads
-    :alt: Python 2.7+/3.4+
+    :alt: Python 2.7+/3.5+
 
 .. image:: https://img.shields.io/badge/pygame-1.9%2B%2F2.0%2B-orange
     :target: https://www.pygame.org

--- a/pygame_menu/baseimage.py
+++ b/pygame_menu/baseimage.py
@@ -149,7 +149,7 @@ class BaseImage(object):
 
     def equals(self, image):
         """
-        Returns true if the image is the same as the object
+        Return true if the image is the same as the object
 
         :param image: Image object
         :type image: BaseImage

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -167,8 +167,8 @@ class Menu(object):
         # Get window size if not given explicitly
         if screen_dimension is not None:
             _utils.assert_vector2(screen_dimension)
-            assert screen_dimension[0] > 0, 'screen width has to be higher than 0.'
-            assert screen_dimension[1] > 0, 'screen height has to be higher than 0.'
+            assert screen_dimension[0] > 0, 'screen width has to be higher than zero'
+            assert screen_dimension[1] > 0, 'screen height has to be higher than zero'
             self._window_size = screen_dimension
         else:
             surface = pygame.display.get_surface()
@@ -179,7 +179,7 @@ class Menu(object):
 
         window_width, window_height = self._window_size
         assert width <= window_width and height <= window_height, \
-            'menu size ({0}x{1}) must be lower than the size of the window ({2}x{3})'.format(
+            'menu size ({0}x{1}) must be lower or equal than the size of the window ({2}x{3})'.format(
                 width, height, window_width, window_height)
 
         # Generate ID if empty
@@ -823,7 +823,7 @@ class Menu(object):
 
     def _filter_widget_attributes(self, kwargs):
         """
-        Return valid widgets attributes from a dictionary.
+        Return the valid widgets attributes from a dictionary.
         The valid (key, value) are removed from the initial
         dictionary.
 
@@ -1135,7 +1135,7 @@ class Menu(object):
 
     def _get_widget_max_position(self):
         """
-        Returns the lower rightmost position of each widgets in Menu.
+        Return the lower rightmost position of each widgets in Menu.
 
         :return: Rightmost position
         :rtype: tuple
@@ -1756,7 +1756,7 @@ class Menu(object):
 
     def get_rect(self):
         """
-        Return Menu rect.
+        Return the Menu rect.
 
         :return: Rect
         :rtype: :py:class:`pygame.Rect`
@@ -1926,12 +1926,31 @@ class Menu(object):
 
     def get_id(self):
         """
-        Returns the ID of the current/base Menu.
+        Return the ID of the current/base Menu.
 
         :return: Menu ID
         :rtype: str
         """
         return self._id
+
+    def get_window_size(self):
+        """
+        Return the window size (px) as a tuple of (width, height).
+
+        :return: Window size in px
+        :rtype: tuple
+        """
+        w, h = self._window_size
+        return w, h
+
+    def get_size(self):
+        """
+        Return the Menu size (px) as a tuple of (width, height).
+
+        :return: Menu size in px
+        :rtype: tuple
+        """
+        return self._width, self._height
 
     def get_widget(self, widget_id, recursive=False):
         """

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -86,6 +86,8 @@ class Menu(object):
     :type onclose: callable, None
     :param rows: Number of rows of each column, None if there's only 1 column
     :type rows: int, None
+    :param screen_dimension: List/Tuple representing the dimensions the menu should reference for sizing/positioning, if None pygame is queried for the display mode.
+    :type screen_dimension: tuple, list, None
     :param theme: Menu theme object, if None use the default theme
     :type theme: :py:class:`pygame_menu.themes.Theme`
     :param kwargs: Optional keyword parameters
@@ -165,15 +167,17 @@ class Menu(object):
         # Get window size if not given explicitly
         if screen_dimension is not None:
             _utils.assert_vector2(screen_dimension)
-            self.window_size = screen_dimension
+            assert screen_dimension[0] > 0, 'screen width has to be higher than 0.'
+            assert screen_dimension[1] > 0, 'screen height has to be higher than 0.'
+            self._window_size = screen_dimension
         else:
             surface = pygame.display.get_surface()
             if surface is None:
                 msg = 'pygame surface could not be retrieved, check if pygame.display.set_mode() was called'
                 raise RuntimeError(msg)
-            self.window_size = surface.get_size()
+            self._window_size = surface.get_size()
 
-        window_width, window_height = self.window_size
+        window_width, window_height = self._window_size
         assert width <= window_width and height <= window_height, \
             'menu size ({0}x{1}) must be lower than the size of the window ({2}x{3})'.format(
                 width, height, window_width, window_height)
@@ -1276,7 +1280,7 @@ class Menu(object):
 
         position_x = float(position_x) / 100
         position_y = float(position_y) / 100
-        window_width, window_height = self.window_size
+        window_width, window_height = self._window_size
         self._pos_x = (window_width - self._width) * position_x
         self._pos_y = (window_height - self._height) * position_y
         self._widgets_surface = None  # This forces an update of the widgets
@@ -1366,7 +1370,7 @@ class Menu(object):
 
         if widget is None or not widget.active or not self._mouse_motion_selection:
             return
-        window_width, window_height = self.window_size
+        window_width, window_height = self._window_size
 
         rect = widget.get_rect()
         if widget.selected and widget.get_selection_effect():

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -165,13 +165,15 @@ class Menu(object):
         # Get window size if not given explicitly
         if screen_dimension is not None:
             _utils.assert_vector2(screen_dimension)
-            window_width, window_height = screen_dimension
+            self.window_size = screen_dimension
         else:
             surface = pygame.display.get_surface()
             if surface is None:
                 msg = 'pygame surface could not be retrieved, check if pygame.display.set_mode() was called'
                 raise RuntimeError(msg)
-            window_width, window_height = surface.get_size()
+            self.window_size = surface.get_size()
+
+        window_width, window_height = self.window_size
         assert width <= window_width and height <= window_height, \
             'menu size ({0}x{1}) must be lower than the size of the window ({2}x{3})'.format(
                 width, height, window_width, window_height)
@@ -1274,7 +1276,7 @@ class Menu(object):
 
         position_x = float(position_x) / 100
         position_y = float(position_y) / 100
-        window_width, window_height = pygame.display.get_surface().get_size()
+        window_width, window_height = self.window_size
         self._pos_x = (window_width - self._width) * position_x
         self._pos_y = (window_height - self._height) * position_y
         self._widgets_surface = None  # This forces an update of the widgets
@@ -1364,7 +1366,7 @@ class Menu(object):
 
         if widget is None or not widget.active or not self._mouse_motion_selection:
             return
-        window_width, window_height = pygame.display.get_surface().get_size()
+        window_width, window_height = self.window_size
 
         rect = widget.get_rect()
         if widget.selected and widget.get_selection_effect():

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -108,6 +108,7 @@ class Menu(object):
                  mouse_visible=True,
                  onclose=None,
                  rows=None,
+                 screen_dimension=None,
                  theme=_themes.THEME_DEFAULT,
                  **kwargs
                  ):
@@ -125,6 +126,7 @@ class Menu(object):
         assert isinstance(mouse_motion_selection, bool)
         assert isinstance(mouse_visible, bool)
         assert isinstance(rows, (int, type(None)))
+        assert isinstance(screen_dimension, (tuple, list, type(None)))
         assert isinstance(theme, _themes.Theme), 'theme bust be an pygame_menu.themes.Theme object instance'
 
         # Assert theme
@@ -160,12 +162,16 @@ class Menu(object):
         assert width > 0 and height > 0, \
             'menu width and height must be greater than zero'
 
-        # Get window size
-        surface = pygame.display.get_surface()
-        if surface is None:
-            msg = 'pygame surface could not be retrieved, check if pygame.display.set_mode() was called'
-            raise RuntimeError(msg)
-        window_width, window_height = surface.get_size()
+        # Get window size if not given explicitly
+        if screen_dimension is not None:
+            _utils.assert_vector2(screen_dimension)
+            window_width, window_height = screen_dimension
+        else:
+            surface = pygame.display.get_surface()
+            if surface is None:
+                msg = 'pygame surface could not be retrieved, check if pygame.display.set_mode() was called'
+                raise RuntimeError(msg)
+            window_width, window_height = surface.get_size()
         assert width <= window_width and height <= window_height, \
             'menu size ({0}x{1}) must be lower than the size of the window ({2}x{3})'.format(
                 width, height, window_width, window_height)

--- a/pygame_menu/scrollarea.py
+++ b/pygame_menu/scrollarea.py
@@ -351,7 +351,7 @@ class ScrollArea(object):
 
     def get_world_size(self):
         """
-        Return world size.
+        Return the world size.
 
         :return: width, height in pixels
         :rtype: tuple
@@ -499,7 +499,7 @@ class ScrollArea(object):
 
     def is_scrolling(self):
         """
-        Returns true if the user is scrolling.
+        Return true if the user is scrolling.
 
         :return: True if user scrolls
         :rtype: bool

--- a/pygame_menu/utils.py
+++ b/pygame_menu/utils.py
@@ -165,7 +165,7 @@ def make_surface(width, height, alpha=False, fill_color=None):
     assert isinstance(height, (int, float))
     assert isinstance(alpha, bool)
     assert isinstance(fill_color, (type(None), tuple))
-    assert width > 0 and height > 0, 'surface width and height must be greater than zero'
+    assert width >= 0 and height >= 0, 'surface width and height must be greater or equal than zero'
     surface = pygame.Surface((int(width), int(height)), pygame.SRCALPHA, 32)  # lgtm [py/call/wrong-arguments]
     if alpha:
         surface = pygame.Surface.convert_alpha(surface)

--- a/pygame_menu/widgets/core/selection.py
+++ b/pygame_menu/widgets/core/selection.py
@@ -104,7 +104,7 @@ class Selection(object):
 
     def get_height(self):
         """
-        Return height as sum of top and bottom margins.
+        Return the selection height as sum of top and bottom margins.
 
         :return: Height in px
         :rtype: int, float

--- a/pygame_menu/widgets/core/widget.py
+++ b/pygame_menu/widgets/core/widget.py
@@ -410,7 +410,7 @@ class Widget(object):
 
     def get_id(self):
         """
-        Returns the widget ID.
+        Return the widget ID.
 
         :return: ID
         :rtype: str
@@ -581,7 +581,7 @@ class Widget(object):
 
     def get_menu(self):
         """
-        Return menu reference (if exists).
+        Return the menu reference (if exists).
 
         :return: Menu reference
         :rtype: :py:class:`pygame_menu.Menu`
@@ -622,7 +622,7 @@ class Widget(object):
 
     def get_alignment(self):
         """
-        Returns widget alignment.
+        Return the widget alignment.
 
         :return: Widget align, see locals
         :rtype: str

--- a/pygame_menu/widgets/widget/textinput.py
+++ b/pygame_menu/widgets/widget/textinput.py
@@ -317,7 +317,7 @@ class TextInput(Widget):
 
     def get_value(self):
         """
-        Returns the value of the text.
+        Return the value of the text.
 
         :return: Text inside the widget
         :rtype: str
@@ -619,7 +619,7 @@ class TextInput(Widget):
 
     def _get_input_string_filtered(self):
         """
-        Returns input string where all filters have been applied.
+        Return the input string where all filters have been applied.
 
         :return: Filtered string
         :rtype: str
@@ -1043,7 +1043,7 @@ class TextInput(Widget):
 
     def _get_selected_text(self):
         """
-        Return text selected.
+        Return the selected text.
 
         :return: Text
         :rtype: str
@@ -1134,7 +1134,7 @@ class TextInput(Widget):
 
     def _get_char_size(self, char):
         """
-        Return char size in pixels.
+        Return the widget char size in pixels.
 
         :param char: Char
         """


### PR DESCRIPTION
In a game I'm developing, I explicitly render to a surface which I later scale up to a higher resolution.
This lead me to attempt to fix this in pygame_menu.

Since pygame_menu queries `pygame.display.get_size()` when it needs to use the screen dimensions for positioning etc. it leads to incorrect positioning when rendered to a surface that is of lower size than the main display.

This PR attempts to solve that by allowing the user to pass in a 2-tuple or list of screen dimensions when instantiating a Menu object, which it then stores for further reference.