### PR TITLE
pygame 1.9.3 support

### DIFF
--- a/pygame_menu/font.py
+++ b/pygame_menu/font.py
@@ -49,6 +49,7 @@ FONT_OPEN_SANS_ITALIC = __fontdir__.format('opensans_italic.ttf')
 FONT_OPEN_SANS_LIGHT = __fontdir__.format('opensans_light.ttf')
 FONT_PT_SERIF = __fontdir__.format('pt_serif.ttf')
 
+fontCache = {}
 
 def get_font(name, size):
     """
@@ -119,6 +120,8 @@ def get_font(name, size):
 
         # Try to load the font
         font = None  # type: (_font.Font,None)
+        if (name,size) in fontCache:
+            return fontCache[(name,size)]
         try:
             font = _font.Font(name, size)
         except IOError:
@@ -127,4 +130,5 @@ def get_font(name, size):
         # If font was not loaded throw an exception
         if font is None:
             raise IOError('font file "{0}" cannot be loaded'.format(font))
+        fontCache[(name,size)] = font
         return font

--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -146,7 +146,7 @@ class Menu(object):
         theme.validate()
 
         # Assert pygame was initialized
-        assert pygame.get_init(), 'pygame is not initialized'
+        assert not hasattr(pygame,'get_init') or pygame.get_init(), 'pygame is not initialized'
 
         # Column/row asserts
         assert columns >= 1, 'number of columns must be greater or equal than 1'

--- a/pygame_menu/scrollarea.py
+++ b/pygame_menu/scrollarea.py
@@ -561,7 +561,7 @@ class ScrollArea(object):
         :return: True if collide
         :rtype: bool
         """
-        if event.type == pygame.FINGERDOWN or event.type == pygame.FINGERUP or event.type == pygame.FINGERMOTION:
+        if hasattr(pygame,'FINGERDOWN') and (event.type == pygame.FINGERDOWN or event.type == pygame.FINGERUP or event.type == pygame.FINGERMOTION):
             display_size = self._menu.get_window_size()
             finger_pos = (event.x * display_size[0], event.y * display_size[1])
             return self.to_real_position(widget.get_rect()).collidepoint(finger_pos)

--- a/pygame_menu/themes.py
+++ b/pygame_menu/themes.py
@@ -199,7 +199,7 @@ class Theme(object):
                                                bool, True)  # type: bool
         self.widget_font_background_color_from_menu = self._get(kwargs,
                                                                 'widget_font_background_color_from_menu',
-                                                                bool, pygame.vernum.major == 2)  # type: bool
+                                                                bool, pygame.vernum[0] == 2)  # type: bool
         self.widget_font_color = self._get(kwargs, 'widget_font_color',
                                            'color', (70, 70, 70))  # type: tuple
         self.widget_font_size = self._get(kwargs, 'widget_font_size',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pygame>=1.9.6
+pygame>=1.9.3
 pyperclip


### PR DESCRIPTION
My system (Raspberry PI 3B+ with Raspbian Stretch) doesn't have pygame 1.9.6, and when I tried to build pygame 1.9.6, the result didn't work windowed. So I modified pygamemenu to work with 1.9.3.

One of the changes is something that gets around a problem, perhaps only in 1.9.3 but maybe also in later versions, where if you open enough very large menus, eventually you get a read error on the widget font, perhaps due to some leak in pygame. To get around this, I added a simple font cache.