### PR TITLE
change now returns new state, not old state

### DIFF
--- a/docs/_source/contributors.rst
+++ b/docs/_source/contributors.rst
@@ -7,13 +7,17 @@ Core developers:
 
 - `Pablo Pizarro R. <https://ppizarror.com>`_
 
-Other contributors:
+Main contributors:
 
 - `anxuae <https://github.com/anxuae>`_
+- `eforgacs <https://github.com/eforgacs>`_
+
+Other contributors:
+
+- `apuly <https://github.com/apuly>`_
 - `arpruss <https://github.com/arpruss>`_
 - `asierrayk <https://github.com/asierrayk>`_
 - `DA820 <https://github.com/DA820>`_
-- `eforgacs <https://github.com/eforgacs>`_
 - `i96751414 <https://github.com/i96751414>`_
 - `ironsmile <https://github.com/ironsmile>`_
 - `jwllee <https://github.com/jwllee>`_

--- a/pygame_menu/__init__.py
+++ b/pygame_menu/__init__.py
@@ -114,6 +114,7 @@ Metadata: Information about the project
 __author__ = 'Pablo Pizarro R.'
 __contributors__ = [
     'anxuae',
+    'apuly',
     'arpruss',
     'asierrayk',
     'DA820',

--- a/pygame_menu/widgets/widget/dropselect_multiple.py
+++ b/pygame_menu/widgets/widget/dropselect_multiple.py
@@ -247,10 +247,24 @@ class DropSelectMultiple(DropSelect):
         return self._option_font.render(text, self._font_antialias, color)
 
     def _click_option(self, index: int, btn: 'Button') -> None:
-        super(DropSelectMultiple, self)._click_option(index, btn)
+        """
+        Function triggered after option has been selected or clicked.
+
+        :param index: Option index within list
+        :return: None
+        """
         btn.set_attribute('ignore_scroll_to_widget')
+        
+        self.set_value(index)
         self._process_index()
-        btn.remove_attribute('ignore_scroll_to_widget')
+
+        #prev_index = self._index
+        if self._index != -1:
+            self.change(*self._items[self._index][1:]+"hello")
+        if self._close_on_apply:
+            self.active = False
+            if self._drop_frame is not None:
+                self._drop_frame.hide()
 
     def _apply_font(self) -> None:
         prev_selection_box_width = self._selection_box_width

--- a/pygame_menu/widgets/widget/dropselect_multiple.py
+++ b/pygame_menu/widgets/widget/dropselect_multiple.py
@@ -232,12 +232,6 @@ class DropSelectMultiple(DropSelect):
         return self._selected_indices.copy()
 
     def _render_option_string(self, text: str) -> 'pygame.Surface':
-        """
-        Render option string surface.
-
-        :param text: Text to render
-        :return: Option string surface
-        """
         color = self._selection_option_font_style['color']
         if self.readonly or \
                 len(self._selected_indices) == 0 or \
@@ -247,24 +241,16 @@ class DropSelectMultiple(DropSelect):
         return self._option_font.render(text, self._font_antialias, color)
 
     def _click_option(self, index: int, btn: 'Button') -> None:
-        """
-        Function triggered after option has been selected or clicked.
-
-        :param index: Option index within list
-        :return: None
-        """
         btn.set_attribute('ignore_scroll_to_widget')
-        
         self.set_value(index)
         self._process_index()
-
-        #prev_index = self._index
         if self._index != -1:
-            self.change(*self._items[self._index][1:]+"hello")
+            self.change(*self._items[self._index][1:])
         if self._close_on_apply:
             self.active = False
             if self._drop_frame is not None:
                 self._drop_frame.hide()
+        btn.remove_attribute('ignore_scroll_to_widget')
 
     def _apply_font(self) -> None:
         prev_selection_box_width = self._selection_box_width
@@ -278,11 +264,6 @@ class DropSelectMultiple(DropSelect):
                                             2 * self._selection_box_border_width)
 
     def _get_current_selected_text(self) -> str:
-        """
-        Return the current selected text.
-
-        :return: Text
-        """
         if len(self._selected_indices) == 0:
             current_selected = self._placeholder
         else:
@@ -357,11 +338,6 @@ class DropSelectMultiple(DropSelect):
         self._update_buttons()
 
     def reset_value(self) -> 'DropSelectMultiple':
-        """
-        Reset the Widget value to the default one.
-
-        :return: Self reference
-        """
         self._index = -1
         self._selected_indices = self._default_value.copy()
         self._update_buttons()

--- a/test/test_widgets.py
+++ b/test/test_widgets.py
@@ -1365,6 +1365,31 @@ class WidgetsTest(unittest.TestCase):
         self.assertTrue(drop2.active)
         self.assertTrue(drop2._drop_frame.is_visible())
 
+        # Test change
+        test = [-1]
+
+        def onchange(value) -> None:
+            """
+            Test onchange.
+            """
+            test[0] = value[1]
+
+        drop2.set_onchange(onchange)
+
+        # Pick any option
+        menu.render()
+        self.assertEqual(test, [-1])
+        drop2._option_buttons[0].apply()
+        self.assertEqual(test[0], [0])
+        drop2._option_buttons[0].apply()
+        self.assertEqual(test[0], [])
+        drop2._option_buttons[0].apply()
+        drop2._option_buttons[1].apply()
+        self.assertEqual(test[0], [0])  # As max selected is only 1
+        drop2._max_selected = 2
+        drop2._option_buttons[1].apply()
+        self.assertEqual(test[0], [0, 1])
+
     def test_dropselect(self) -> None:
         """
         Test dropselect widget.


### PR DESCRIPTION
I encountered what (to me) seem like a bug while working with the dropselect_multiple
Whenever I would pick any option, the onchange callback would return the state of the widget before pressing the button.
To me it seemed it should return the state of the widget after picking an option.

I've copy-pasted code from the dropselect widget, moved some things around and removed a check and now it functions as I expected it to.

You've made some mighty fine code here.