### PR TITLE
Add cursor size for text input

### DIFF
--- a/pygame_menu/_widgetmanager.py
+++ b/pygame_menu/_widgetmanager.py
@@ -2025,6 +2025,7 @@ class WidgetManager(Base):
             default: Union[str, int, float] = '',
             copy_paste_enable: bool = True,
             cursor_selection_enable: bool = True,
+            cursor_size: Tuple[int, ...] = None,
             input_type: str = INPUT_TEXT,
             input_underline: str = '',
             input_underline_len: int = 0,

--- a/pygame_menu/_widgetmanager.py
+++ b/pygame_menu/_widgetmanager.py
@@ -56,7 +56,7 @@ from pygame_menu.widgets.widget.selector import SelectorStyleType, SELECTOR_STYL
 
 from pygame_menu._types import Any, Union, Callable, Dict, Optional, CallbackType, \
     PaddingInstance, NumberType, Vector2NumberType, List, Tuple, NumberInstance, \
-    Tuple3IntType
+    Tuple3IntType, Tuple2IntType
 
 
 # noinspection PyProtectedMember
@@ -2025,7 +2025,7 @@ class WidgetManager(Base):
             default: Union[str, int, float] = '',
             copy_paste_enable: bool = True,
             cursor_selection_enable: bool = True,
-            cursor_size: Tuple[int, ...] = None,
+            cursor_size: Optional[Tuple2IntType] = None,
             input_type: str = INPUT_TEXT,
             input_underline: str = '',
             input_underline_len: int = 0,
@@ -2104,6 +2104,7 @@ class WidgetManager(Base):
         :param default: Default value to display
         :param copy_paste_enable: Enable text copy, paste and cut
         :param cursor_selection_enable: Enable text selection on input
+        :param cursor_size: Size of the cursor (width, height) in px. If ``None`` uses the default sizing
         :param input_type: Data type of the input. See :py:mod:`pygame_menu.locals`
         :param input_underline: Underline character
         :param input_underline_len: Total of characters to be drawn under the input. If ``0`` this number is computed automatically to fit the font

--- a/pygame_menu/_widgetmanager.py
+++ b/pygame_menu/_widgetmanager.py
@@ -2134,6 +2134,7 @@ class WidgetManager(Base):
             cursor_color=self._theme.cursor_color,
             cursor_selection_color=self._theme.cursor_selection_color,
             cursor_selection_enable=cursor_selection_enable,
+            cursor_size=cursor_size,
             cursor_switch_ms=self._theme.cursor_switch_ms,
             input_type=input_type,
             input_underline=input_underline,

--- a/pygame_menu/widgets/widget/textinput.py
+++ b/pygame_menu/widgets/widget/textinput.py
@@ -315,6 +315,7 @@ class TextInput(Widget):
         self._cursor_render = True  # If True cursor must be rendered
         self._cursor_surface = None
         self._cursor_surface_pos = [0, 0]  # Position (x,y) of surface
+        self._cursor_size = cursor_size
         self._cursor_switch_ms = cursor_switch_ms
         self._cursor_visible = False  # Switches every self._cursor_switch_ms ms
 

--- a/pygame_menu/widgets/widget/textinput.py
+++ b/pygame_menu/widgets/widget/textinput.py
@@ -38,7 +38,7 @@ import pygame
 from pygame_menu.controls import KEY_MOVE_UP, KEY_MOVE_DOWN, KEY_APPLY
 from pygame_menu.locals import FINGERDOWN, FINGERUP, INPUT_INT, INPUT_FLOAT, INPUT_TEXT
 from pygame_menu.utils import check_key_pressed_valid, make_surface, assert_color, \
-    get_finger_pos, warn
+    get_finger_pos, warn, assert_vector
 from pygame_menu.widgets.core import Widget
 
 from pygame_menu._types import Optional, Any, CallbackType, Tuple, List, ColorType, \
@@ -140,7 +140,7 @@ class TextInput(Widget):
     _cursor_offset: NumberType
     _cursor_position: int
     _cursor_render: bool
-    _cursor_size: Tuple[int, ...]
+    _cursor_size: Optional[Tuple2IntType]  # Size defined by user
     _cursor_surface: Optional['pygame.Surface']
     _cursor_surface_pos: List[int]
     _cursor_switch_ms: NumberType
@@ -197,7 +197,7 @@ class TextInput(Widget):
             cursor_color: ColorInputType = (0, 0, 0),
             cursor_selection_color: ColorInputType = (30, 30, 30, 100),
             cursor_selection_enable: bool = True,
-            cursor_size: Tuple[int, ...] = None,
+            cursor_size: Optional[Tuple2IntType] = None,
             cursor_switch_ms: NumberType = 500,
             history: int = 50,
             input_type: str = INPUT_TEXT,
@@ -223,6 +223,7 @@ class TextInput(Widget):
     ) -> None:
         assert isinstance(copy_paste_enable, bool)
         assert isinstance(cursor_selection_enable, bool)
+        assert isinstance(cursor_size, (type(None), tuple))
         assert isinstance(cursor_switch_ms, NumberInstance)
         assert isinstance(history, int)
         assert isinstance(input_type, str)
@@ -257,6 +258,13 @@ class TextInput(Widget):
                 'cursor selection color alpha must be defined'
             assert cursor_selection_color[3] != 255, \
                 'cursor selection color alpha cannot be opaque'
+
+        if cursor_size is not None:
+            assert_vector(cursor_size, 2, int)
+            assert cursor_size[0] > 0, \
+                'cursor size width must be greater than zero'
+            assert cursor_size[1] > 0, \
+                'cursor size height must be greater than zero'
 
         super(TextInput, self).__init__(
             args=args,

--- a/pygame_menu/widgets/widget/textinput.py
+++ b/pygame_menu/widgets/widget/textinput.py
@@ -105,6 +105,7 @@ class TextInput(Widget):
     :param cursor_color: Color of cursor
     :param cursor_selection_color: Color of the text selection if the cursor is enabled on certain widgets
     :param cursor_selection_enable: Enables selection of text
+    :param cursor_size: Set surface x,y of the cursor which determines cursor size
     :param cursor_switch_ms: Interval of cursor switch between off and on status. First status is ``off``
     :param history: Maximum number of editions stored
     :param input_type: Type of the input data. See :py:mod:`pygame_menu.locals`
@@ -139,6 +140,7 @@ class TextInput(Widget):
     _cursor_offset: NumberType
     _cursor_position: int
     _cursor_render: bool
+    _cursor_size: Tuple[int, ...]
     _cursor_surface: Optional['pygame.Surface']
     _cursor_surface_pos: List[int]
     _cursor_switch_ms: NumberType
@@ -195,6 +197,7 @@ class TextInput(Widget):
             cursor_color: ColorInputType = (0, 0, 0),
             cursor_selection_color: ColorInputType = (30, 30, 30, 100),
             cursor_selection_enable: bool = True,
+            cursor_size: Tuple[int, ...] = None,
             cursor_switch_ms: NumberType = 500,
             history: int = 50,
             input_type: str = INPUT_TEXT,
@@ -684,8 +687,11 @@ class TextInput(Widget):
         if self._cursor_surface is None:
             if self._rect.height == 0:  # If Menu has not been initialized this error can occur
                 return
-            self._cursor_surface = make_surface(self._font_size / 20 + 1,
-                                                self._rect.height - 2)
+            if self._cursor_size is not None:
+                self._cursor_surface = make_surface(*self._cursor_size)
+            else:
+                self._cursor_surface = make_surface(self._font_size / 20 + 1,
+                                                    self._rect.height - 2)
             self._cursor_surface.fill(self._cursor_color)
 
         # Get string

--- a/test/test_widgets.py
+++ b/test/test_widgets.py
@@ -920,7 +920,7 @@ class WidgetsTest(unittest.TestCase):
         # Check title format
         self.assertRaises(AssertionError, lambda: menu.add.clock(title_format='bad'))
 
-    # noinspection SpellCheckingInspection
+    # noinspection SpellCheckingInspection,PyTypeChecker
     def test_textinput(self) -> None:
         """
         Test TextInput widget.
@@ -1252,6 +1252,16 @@ class WidgetsTest(unittest.TestCase):
         self.assertEqual(menu._widget_offset[1], 76 if PYGAME_V2 else 75)
         self.assertEqual(textinput.get_width(), 134)
         self.assertEqual(textinput._current_underline_string, '________')
+
+        # Test cursor size
+        self.assertRaises(AssertionError, lambda: menu.add.text_input('title', cursor_size=(1, 0)))
+        self.assertRaises(AssertionError, lambda: menu.add.text_input('title', cursor_size=(-1, -1)))
+        self.assertRaises(AssertionError, lambda: menu.add.text_input('title', cursor_size=(1, 1, 0)))
+        self.assertRaises(AssertionError, lambda: menu.add.text_input('title', cursor_size=[1, 1]))
+        self.assertRaises(AssertionError, lambda: menu.add.text_input('title', cursor_size=(1.6, 2.5)))
+
+        textinput_cursor = menu.add.text_input('title', cursor_size=(10, 2))
+        self.assertEqual(textinput_cursor._cursor_size, (10, 2))
 
     def test_button(self) -> None:
         """


### PR DESCRIPTION
I am working on textinput for small screens, while i am using textinput font size 15, the cursor is not following the size.
Hence added an option to declare cursor size.