### PR TITLE
Add py.typed

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ exclude pygame_menu/examples/other/_test*
 exclude test/*.py
 
 include requirements.txt
+include pygame_menu/py.typed
 
 recursive-include pygame_menu/resources/fonts *.ttf
 recursive-include pygame_menu/resources/fonts *.txt


### PR DESCRIPTION
Closes #388.

Honestly, I am not sure how to test that it works until you package it, as Mypy takes into account typing in your own projects even if they don't have py.typed.