### PR TITLE
Fix adding a frame before all columns are started

### DIFF
--- a/pygame_menu/menu.py
+++ b/pygame_menu/menu.py
@@ -1342,7 +1342,10 @@ class Menu(Base):
         # If some columns were not used, set these widths to zero
         for col in range(self._used_columns, self._columns):
             column_widths.pop()
-            del self._widget_columns[col]
+            try:
+                del self._widget_columns[col]
+            except KeyError:
+                pass
 
         # If the total weight is less than the window width (so there's no horizontal
         # scroll), scale the columns. Only None column_max_widths and columns less


### PR DESCRIPTION
Ignoring KeyError seems to work out...

![expected_2_column_menu_with_frame](https://user-images.githubusercontent.com/115673318/209528730-6186b7e8-17bc-473e-97e8-f0bde18134da.png)
