### PR TITLE
Fix for submenus to be subclasses of pygame.Menu

### DIFF
--- a/pygame_menu/version.py
+++ b/pygame_menu/version.py
@@ -32,6 +32,6 @@ class Version(tuple):
     patch = property(lambda self: self[2])
 
 
-vernum = Version(4, 4, 3)
+vernum = Version(4, 4, 4)
 ver = str(vernum)
 rev = ''

--- a/pygame_menu/widgets/widget/button.py
+++ b/pygame_menu/widgets/widget/button.py
@@ -445,7 +445,7 @@ class ButtonManager(AbstractWidgetManager, ABC):
             action = _events.NONE
 
         # If element is a Menu
-        if isinstance(action, pygame.Menu):
+        if isinstance(action, pygame_menu.Menu):
             # Check for recursive
             if action == self._menu or action.in_submenu(self._menu, recursive=True):
                 raise ValueError(

--- a/pygame_menu/widgets/widget/button.py
+++ b/pygame_menu/widgets/widget/button.py
@@ -445,7 +445,7 @@ class ButtonManager(AbstractWidgetManager, ABC):
             action = _events.NONE
 
         # If element is a Menu
-        if isinstance(action, type(self._menu)):
+        if isinstance(action, pygame.Menu):
             # Check for recursive
             if action == self._menu or action.in_submenu(self._menu, recursive=True):
                 raise ValueError(


### PR DESCRIPTION
See https://github.com/ppizarror/pygame-menu/issues/482.

This is a very simple change. I've replaced the current `if` statement here to compare against the type `pygame.Menu` directly.

This works in my use case and for `test/test_widget_button.py`, but I have not performed any other testing on this.