### PR TITLE
Add wordwrap feature in Button Widget - Fixes #488

### DIFF
--- a/docs/_source/contributors.rst
+++ b/docs/_source/contributors.rst
@@ -32,6 +32,7 @@ Other contributors:
 - `vnmabus <https://github.com/vnmabus>`_
 - `werdeil <https://github.com/werdeil>`_
 - `zPaw <https://github.com/zPaw>`_
+- `neilsimp1 <https://github.com/neilsimp1>`_
 
 Ideas and contributions are always welcome. Any found bugs or enhancement
 suggestions should be posted on the `GitHub project page <https://github.com/ppizarror/pygame-menu>`_.


### PR DESCRIPTION
This is an initial commit which copies some code from the Label widget into Button.
This works in my use cases but could of course use more testing. There's also some code duplicated that might be better put in the Widget base class.

If you are interested in accepting this sort of change, I'd be happy to refactor the code to remove the duplication, or anything else you'd suggest.

___

Example from the project I'm using this in...
In Code:
![image](https://github.com/user-attachments/assets/0771b794-56e7-4242-8717-d27c32cab29f)
![image](https://github.com/user-attachments/assets/ad3d3a7d-0c31-438a-b847-caa4646ad844)

In game, here is the button in it's default state.
![image](https://github.com/user-attachments/assets/e8b6419f-b2fc-4b45-88e3-e4c51b5612b0)

When an item is selected, sometimes the text is too wide for the button, so this allows the text to flow to the next line:
![image](https://github.com/user-attachments/assets/fb65c248-82c0-4574-875f-b4b06bb384f5)

Happy holidays!
