### PR TITLE
Replace deprecated `pygame.image.fromstring` with `pygame.image.frombytes`

### DIFF
--- a/pygame_menu/utils.py
+++ b/pygame_menu/utils.py
@@ -403,7 +403,7 @@ def load_pygame_image_file(image_path: str, **kwargs) -> 'pygame.Surface':
                 pil_invalid_exception = UnidentifiedImageError
                 img_pil = Image.open(image_path)
                 # noinspection PyTypeChecker,PyUnusedLocal
-                surface = pygame.image.fromstring(
+                surface = pygame.image.frombytes(
                     img_pil.tobytes(), img_pil.size, img_pil.mode).convert()
             except (ModuleNotFoundError, ImportError):
                 warn(f'Image file "{image_path}" could not be loaded, as pygame.error '


### PR DESCRIPTION
The function `pygame.image.fromstring` has been deprecated since Pygame version 2.3.0. As per the official documentation, `pygame.image.frombytes` should be used instead. This update ensures compatibility with newer versions of Pygame while maintaining the intended functionality.